### PR TITLE
Improve ZIO interop 

### DIFF
--- a/modules/inject-zio/src/main/scala/io/janstenpickle/trace4cats/inject/zio/SpannedEnvRIOTracer.scala
+++ b/modules/inject-zio/src/main/scala/io/janstenpickle/trace4cats/inject/zio/SpannedEnvRIOTracer.scala
@@ -1,0 +1,55 @@
+package io.janstenpickle.trace4cats.inject.zio
+
+import cats.syntax.show._
+import io.janstenpickle.trace4cats.inject.Trace
+import io.janstenpickle.trace4cats.model.{AttributeValue, SpanKind, SpanStatus, TraceHeaders}
+import io.janstenpickle.trace4cats.{ErrorHandler, Span, ToHeaders}
+import zio.blocking.Blocking
+import zio.clock.Clock
+import zio.interop.catz._
+import zio.{Has, RIO, ZIO}
+
+/** For use with ZLayers
+  */
+class SpannedEnvRIOTracer[Env <: Clock with Blocking with Has[Span[RIO[Clock with Blocking, *]]]]
+    extends Trace[SpannedEnvRIO[Env, *]] {
+  override def put(key: String, value: AttributeValue): SpannedEnvRIO[Env, Unit] =
+    ZIO
+      .service[Span[RIO[Clock with Blocking, *]]]
+      .flatMap(_.put(key, value))
+
+  override def putAll(fields: (String, AttributeValue)*): SpannedEnvRIO[Env, Unit] =
+    ZIO
+      .service[Span[RIO[Clock with Blocking, *]]]
+      .flatMap(_.putAll(fields: _*))
+
+  override def span[A](name: String, kind: SpanKind, errorHandler: ErrorHandler)(
+    fa: SpannedEnvRIO[Env, A]
+  ): SpannedEnvRIO[Env, A] = {
+    for {
+      env <- ZIO.environment[Env]
+      span <- ZIO.service[Span[RIO[Clock with Blocking, *]]]
+      result <- span
+        .child(name, kind, errorHandler)
+        .use { (childSpan: Span[RIO[Clock with Blocking, *]]) =>
+          val deps = env ++ Has(childSpan)
+          fa.provide(deps)
+        }
+    } yield result
+  }
+
+  override def headers(toHeaders: ToHeaders): SpannedEnvRIO[Env, TraceHeaders] =
+    ZIO
+      .service[Span[RIO[Clock with Blocking, *]]]
+      .map(s => toHeaders.fromContext(s.context))
+
+  override def setStatus(status: SpanStatus): SpannedEnvRIO[Env, Unit] =
+    ZIO
+      .service[Span[RIO[Clock with Blocking, *]]]
+      .flatMap(_.setStatus(status))
+
+  override def traceId: SpannedEnvRIO[Env, Option[String]] =
+    ZIO.service[Span[RIO[Clock with Blocking, *]]].map { s =>
+      Some(s.context.traceId.show)
+    }
+}

--- a/modules/inject-zio/src/main/scala/io/janstenpickle/trace4cats/inject/zio/SpannedRIOTracer.scala
+++ b/modules/inject-zio/src/main/scala/io/janstenpickle/trace4cats/inject/zio/SpannedRIOTracer.scala
@@ -29,7 +29,7 @@ class SpannedRIOTracer[Env <: Clock with Blocking with Has[Span[RIO[Clock with B
       span <- ZIO.service[Span[RIO[Clock with Blocking, *]]]
       result <- span
         .child(name, kind, errorHandler)
-        .use { childSpan: Span[RIO[Clock with Blocking, *]] =>
+        .use { childSpan =>
           val deps = env ++ Has(childSpan)
           fa.provide(deps)
         }

--- a/modules/inject-zio/src/main/scala/io/janstenpickle/trace4cats/inject/zio/SpannedRIOTracer.scala
+++ b/modules/inject-zio/src/main/scala/io/janstenpickle/trace4cats/inject/zio/SpannedRIOTracer.scala
@@ -29,7 +29,7 @@ class SpannedRIOTracer[Env <: Clock with Blocking with Has[Span[RIO[Clock with B
       span <- ZIO.service[Span[RIO[Clock with Blocking, *]]]
       result <- span
         .child(name, kind, errorHandler)
-        .use { childSpan =>
+        .use { (childSpan: Span[RIO[Clock with Blocking, *]]) =>
           val deps = env ++ Has(childSpan)
           fa.provide(deps)
         }

--- a/modules/inject-zio/src/main/scala/io/janstenpickle/trace4cats/inject/zio/SpannedRIOTracer.scala
+++ b/modules/inject-zio/src/main/scala/io/janstenpickle/trace4cats/inject/zio/SpannedRIOTracer.scala
@@ -4,33 +4,54 @@ import cats.syntax.show._
 import io.janstenpickle.trace4cats.inject.Trace
 import io.janstenpickle.trace4cats.model.{AttributeValue, SpanKind, SpanStatus, TraceHeaders}
 import io.janstenpickle.trace4cats.{ErrorHandler, Span, ToHeaders}
+import zio.blocking.Blocking
+import zio.clock.Clock
 import zio.interop.catz._
-import zio.{RIO, Task, ZIO}
+import zio.{Has, RIO, ZIO}
 
-class SpannedRIOTracer extends Trace[SpannedRIO] {
-  override def put(key: String, value: AttributeValue): SpannedRIO[Unit] =
-    ZIO.environment[Span[Task]].flatMap(_.put(key, value))
+class SpannedRIOTracer[Env <: Clock with Blocking with Has[Span[RIO[Clock with Blocking, *]]]]
+    extends Trace[SpannedRIO[Env, *]] {
+  override def put(key: String, value: AttributeValue): SpannedRIO[Env, Unit] =
+    ZIO
+      .service[Span[RIO[Clock with Blocking, *]]]
+      .flatMap(_.put(key, value))
 
-  override def putAll(fields: (String, AttributeValue)*): SpannedRIO[Unit] =
-    ZIO.environment[Span[Task]].flatMap(_.putAll(fields: _*))
+  override def putAll(fields: (String, AttributeValue)*): SpannedRIO[Env, Unit] =
+    ZIO
+      .service[Span[RIO[Clock with Blocking, *]]]
+      .flatMap(_.putAll(fields: _*))
 
-  override def span[A](name: String, kind: SpanKind, errorHandler: ErrorHandler)(fa: SpannedRIO[A]): SpannedRIO[A] =
-    ZIO.environment[Span[Task]].flatMap(_.child(name, kind, errorHandler).use(fa.provide))
+  override def span[A](name: String, kind: SpanKind, errorHandler: ErrorHandler)(
+    fa: SpannedRIO[Env, A]
+  ): SpannedRIO[Env, A] = {
+    for {
+      env <- ZIO.environment[Env]
+      span <- ZIO.service[Span[RIO[Clock with Blocking, *]]]
+      result <- span
+        .child(name, kind, errorHandler)
+        .use { childSpan: Span[RIO[Clock with Blocking, *]] =>
+          val deps = env ++ Has(childSpan)
+          fa.provide(deps)
+        }
+    } yield result
+  }
 
-  override def headers(toHeaders: ToHeaders): SpannedRIO[TraceHeaders] =
-    ZIO.environment[Span[Task]].map { s =>
-      toHeaders.fromContext(s.context)
-    }
+  override def headers(toHeaders: ToHeaders): SpannedRIO[Env, TraceHeaders] =
+    ZIO
+      .service[Span[RIO[Clock with Blocking, *]]]
+      .map(s => toHeaders.fromContext(s.context))
 
-  override def setStatus(status: SpanStatus): SpannedRIO[Unit] =
-    ZIO.environment[Span[Task]].flatMap(_.setStatus(status))
+  override def setStatus(status: SpanStatus): SpannedRIO[Env, Unit] =
+    ZIO
+      .service[Span[RIO[Clock with Blocking, *]]]
+      .flatMap(_.setStatus(status))
 
-  override def traceId: SpannedRIO[Option[String]] =
-    ZIO.environment[Span[Task]].map { s =>
+  override def traceId: SpannedRIO[Env, Option[String]] =
+    ZIO.service[Span[RIO[Clock with Blocking, *]]].map { s =>
       Some(s.context.traceId.show)
     }
 
-  def lens[R](f: R => Span[Task], g: (R, Span[Task]) => R): Trace[RIO[R, *]] =
+  def lens[R](f: R => Span[RIO[R, *]], g: (R, Span[RIO[R, *]]) => R): Trace[RIO[R, *]] =
     new Trace[RIO[R, *]] {
       override def put(key: String, value: AttributeValue): RIO[R, Unit] =
         ZIO.environment[R].flatMap { r =>

--- a/modules/inject-zio/src/main/scala/io/janstenpickle/trace4cats/inject/zio/ZIOTraceInstances.scala
+++ b/modules/inject-zio/src/main/scala/io/janstenpickle/trace4cats/inject/zio/ZIOTraceInstances.scala
@@ -1,5 +1,12 @@
 package io.janstenpickle.trace4cats.inject.zio
 
+import io.janstenpickle.trace4cats.Span
+import zio.blocking.Blocking
+import zio.clock.Clock
+import zio.{Has, RIO}
+
 trait ZIOTraceInstances {
-  implicit val spannedRIOTrace: SpannedRIOTracer = new SpannedRIOTracer
+  implicit def spannedRIOTrace[R <: Clock with Blocking with Has[Span[RIO[Clock with Blocking, *]]]]: SpannedRIOTracer[
+    R
+  ] = new SpannedRIOTracer[R]
 }

--- a/modules/inject-zio/src/main/scala/io/janstenpickle/trace4cats/inject/zio/ZIOTraceInstances.scala
+++ b/modules/inject-zio/src/main/scala/io/janstenpickle/trace4cats/inject/zio/ZIOTraceInstances.scala
@@ -6,7 +6,11 @@ import zio.clock.Clock
 import zio.{Has, RIO}
 
 trait ZIOTraceInstances {
-  implicit def spannedRIOTrace[R <: Clock with Blocking with Has[Span[RIO[Clock with Blocking, *]]]]: SpannedRIOTracer[
-    R
-  ] = new SpannedRIOTracer[R]
+  implicit val spannedRIOTrace: SpannedRIOTracer = new SpannedRIOTracer
+}
+
+trait ZIOHasTraceInstances {
+  implicit def spannedEnvRIOTrace[
+    R <: Clock with Blocking with Has[Span[RIO[Clock with Blocking, *]]]
+  ]: SpannedEnvRIOTracer[R] = new SpannedEnvRIOTracer[R]
 }

--- a/modules/inject-zio/src/main/scala/io/janstenpickle/trace4cats/inject/zio/package.scala
+++ b/modules/inject-zio/src/main/scala/io/janstenpickle/trace4cats/inject/zio/package.scala
@@ -1,11 +1,15 @@
 package io.janstenpickle.trace4cats.inject
 
-import _root_.zio.{Has, RIO}
+import _root_.zio.{Has, RIO, Task}
 import _root_.zio.clock.Clock
 import _root_.zio.blocking.Blocking
 import io.janstenpickle.trace4cats.Span
 import io.janstenpickle.trace4cats.base.context.zio.ZIOContextInstances
 
-package object zio extends ZIOTraceInstances with ZIOContextInstances {
-  type SpannedRIO[-R <: Clock with Blocking with Has[Span[RIO[Clock with Blocking, *]]], +A] = RIO[R, A]
+package object zio extends ZIOTraceInstances with ZIOHasTraceInstances with ZIOContextInstances {
+  // For use with ZLayers
+  type SpannedEnvRIO[-R <: Clock with Blocking with Has[Span[RIO[Clock with Blocking, *]]], +A] = RIO[R, A]
+
+  // For use with Tagless Final style/no ZLayers
+  type SpannedRIO[+A] = RIO[Span[Task], A]
 }

--- a/modules/inject-zio/src/main/scala/io/janstenpickle/trace4cats/inject/zio/package.scala
+++ b/modules/inject-zio/src/main/scala/io/janstenpickle/trace4cats/inject/zio/package.scala
@@ -1,9 +1,11 @@
 package io.janstenpickle.trace4cats.inject
 
-import _root_.zio.{RIO, Task}
+import _root_.zio.{Has, RIO}
+import _root_.zio.clock.Clock
+import _root_.zio.blocking.Blocking
 import io.janstenpickle.trace4cats.Span
 import io.janstenpickle.trace4cats.base.context.zio.ZIOContextInstances
 
 package object zio extends ZIOTraceInstances with ZIOContextInstances {
-  type SpannedRIO[A] = RIO[Span[Task], A]
+  type SpannedRIO[-R <: Clock with Blocking with Has[Span[RIO[Clock with Blocking, *]]], +A] = RIO[R, A]
 }

--- a/modules/inject-zio/src/test/scala/io/janstenpickle/trace4cats/inject/zio/Env.scala
+++ b/modules/inject-zio/src/test/scala/io/janstenpickle/trace4cats/inject/zio/Env.scala
@@ -2,12 +2,9 @@ package io.janstenpickle.trace4cats.inject.zio
 
 import io.janstenpickle.trace4cats.Span
 import io.janstenpickle.trace4cats.base.optics.Lens
-import zio.RIO
-import zio.blocking.Blocking
-import zio.clock.Clock
+import zio.Task
 
-case class Env(dummy: String, span: Span[RIO[Clock with Blocking, *]])
+final case class Env(dummy: String, span: Span[Task])
 object Env {
-  def span: Lens[Env, Span[RIO[Clock with Blocking, *]]] =
-    Lens[Env, Span[RIO[Clock with Blocking, *]]](_.span)(s => _.copy(span = s))
+  def span: Lens[Env, Span[Task]] = Lens[Env, Span[Task]](_.span)(s => _.copy(span = s))
 }

--- a/modules/inject-zio/src/test/scala/io/janstenpickle/trace4cats/inject/zio/Env.scala
+++ b/modules/inject-zio/src/test/scala/io/janstenpickle/trace4cats/inject/zio/Env.scala
@@ -2,9 +2,12 @@ package io.janstenpickle.trace4cats.inject.zio
 
 import io.janstenpickle.trace4cats.Span
 import io.janstenpickle.trace4cats.base.optics.Lens
-import zio.Task
+import zio.RIO
+import zio.blocking.Blocking
+import zio.clock.Clock
 
-case class Env(dymmy: String, span: Span[Task])
+case class Env(dummy: String, span: Span[RIO[Clock with Blocking, *]])
 object Env {
-  def span: Lens[Env, Span[Task]] = Lens[Env, Span[Task]](_.span)(s => _.copy(span = s))
+  def span: Lens[Env, Span[RIO[Clock with Blocking, *]]] =
+    Lens[Env, Span[RIO[Clock with Blocking, *]]](_.span)(s => _.copy(span = s))
 }

--- a/modules/inject-zio/src/test/scala/io/janstenpickle/trace4cats/inject/zio/ZIOTraceInstanceSummonTest.scala
+++ b/modules/inject-zio/src/test/scala/io/janstenpickle/trace4cats/inject/zio/ZIOTraceInstanceSummonTest.scala
@@ -8,23 +8,23 @@ import zio.clock.Clock
 import zio.console.Console
 import zio.interop.catz._
 import zio.random.Random
-import zio.{Has, RIO, ZEnv}
+import zio.{Has, RIO, Task, ZEnv}
 
 object ZIOTraceInstanceSummonTest {
   type Effect[+A] = RIO[Clock with Blocking, A]
 
-  type F[x] = SpannedRIO[Clock with Blocking with Has[Span[Effect]], x]
+  type F[x] = SpannedEnvRIO[Clock with Blocking with Has[Span[Effect]], x]
   implicitly[Trace[F]]
 
-  type ZSpan = Has[Span[Effect]]
-  type G[x] = RIO[ZEnv with ZSpan, x]
-  implicit val rioLayeredLocalSpan: Local[G, Span[Effect]] =
-    zioProvideSome[ZEnv, ZEnv with ZSpan, Throwable, Span[Effect]]
+  type G[x] = RIO[ZEnv with Has[Span[Task]], x]
+  implicit val rioLayeredLocalSpan: Local[G, Span[Task]] =
+    zioProvideSome[ZEnv, ZEnv with Has[Span[Task]], Throwable, Span[Task]]
 
   implicitly[Trace[G]]
 
-  type H[x] = RIO[Clock with Blocking with Has[Env], x]
-  implicit val rioLocalSpan: Local[H, Span[RIO[Clock with Blocking, *]]] =
+  // Lens behavior relies on the non ZLayer instances
+  type H[x] = RIO[Env, x]
+  implicit val rioLocalSpan: Local[H, Span[Task]] =
     Local[H, Env].focus(Env.span)
   implicitly[Trace[H]]
 

--- a/modules/inject-zio/src/test/scala/io/janstenpickle/trace4cats/inject/zio/ZIOTraceInstanceSummonTest.scala
+++ b/modules/inject-zio/src/test/scala/io/janstenpickle/trace4cats/inject/zio/ZIOTraceInstanceSummonTest.scala
@@ -3,19 +3,31 @@ package io.janstenpickle.trace4cats.inject.zio
 import io.janstenpickle.trace4cats.Span
 import io.janstenpickle.trace4cats.base.context.Local
 import io.janstenpickle.trace4cats.inject.Trace
+import zio.blocking.Blocking
+import zio.clock.Clock
+import zio.console.Console
 import zio.interop.catz._
-import zio.{Has, RIO, Task, ZEnv}
+import zio.random.Random
+import zio.{Has, RIO, ZEnv}
 
 object ZIOTraceInstanceSummonTest {
-  type F[x] = SpannedRIO[x]
+  type Effect[+A] = RIO[Clock with Blocking, A]
+
+  type F[x] = SpannedRIO[Clock with Blocking with Has[Span[Effect]], x]
   implicitly[Trace[F]]
 
-  type ZSpan = Has[Span[Task]]
+  type ZSpan = Has[Span[Effect]]
   type G[x] = RIO[ZEnv with ZSpan, x]
-  implicit val rioLayeredLocalSpan: Local[G, Span[Task]] = zioProvideSome[ZEnv, ZEnv with ZSpan, Throwable, Span[Task]]
+  implicit val rioLayeredLocalSpan: Local[G, Span[Effect]] =
+    zioProvideSome[ZEnv, ZEnv with ZSpan, Throwable, Span[Effect]]
+
   implicitly[Trace[G]]
 
-  type H[x] = RIO[Env, x]
-  implicit val rioLocalSpan: Local[H, Span[Task]] = Local[H, Env].focus(Env.span)
+  type H[x] = RIO[Clock with Blocking with Has[Env], x]
+  implicit val rioLocalSpan: Local[H, Span[RIO[Clock with Blocking, *]]] =
+    Local[H, Env].focus(Env.span)
   implicitly[Trace[H]]
+
+  type I[x] = RIO[Clock with Blocking with Console with Random with Has[Span[Effect]], x]
+  implicitly[Trace[I]].span("Hello")(RIO.succeed("World"))
 }


### PR DESCRIPTION
Hey all, 

Thank you very much for this useful library! We have a client that does not make use of Tagless Final and commits to using ZIO throughout the application along with ZLayers for dependency management which results in the use of a `Has` that interferes with the current zio interop. The new implementation allows you to freely use parts of the ZIO environment along with the ZIO interop Trace4Cats in a more ergonomic way.  

The previous implementation would result in the following errors if I tried to use ZIO directly with Http4S due to the lack of variance + not using Has[Span[...]] but rather using Span[...] directly when it came to the environment:
![image](https://user-images.githubusercontent.com/14280155/150198106-85f0f3d7-ac38-486c-b062-d00dc257f4bb.png)


After the changes, this compiles perfectly and infers all the dependencies automatically (including widening to account for more) which is amazing for the user:
```scala
package io.janstenpickle.trace4cats.example

import cats.effect.kernel.{Async, Resource, Sync}
import io.janstenpickle.trace4cats.Span
import io.janstenpickle.trace4cats.base.context.Provide
import io.janstenpickle.trace4cats.http4s.client.syntax.TracedClient
import io.janstenpickle.trace4cats.http4s.common.Http4sRequestFilter
import io.janstenpickle.trace4cats.http4s.server.syntax._
import io.janstenpickle.trace4cats.inject.EntryPoint
import io.janstenpickle.trace4cats.inject.zio._
import io.janstenpickle.trace4cats.kernel.SpanSampler
import io.janstenpickle.trace4cats.model.TraceProcess
import io.janstenpickle.trace4cats.newrelic.NewRelicSpanCompleter
import org.http4s.HttpRoutes
import org.http4s.blaze.client.BlazeClientBuilder
import org.http4s.blaze.server.BlazeServerBuilder
import org.http4s.client.Client
import org.http4s.client.middleware.{RequestLogger, ResponseLogger}
import org.http4s.dsl.Http4sDsl
import org.http4s.implicits._
import zio._
import zio.blocking.Blocking
import zio.clock.Clock
import zio.interop.catz._
import zio.duration._

object Http4sZioExample2 extends CatsApp {
  type Effect[A] = RIO[Clock & Blocking, A]
  type TracedEffect[A] = RIO[Clock & Blocking & Has[Span[Effect]], A]

  def entryPoint[F[_]: Async](process: TraceProcess): Resource[F, EntryPoint[F]] = {
    for {
      client <- BlazeClientBuilder[F].resource
      completer <- NewRelicSpanCompleter[F](
        client = RequestLogger[F](
          logHeaders = true,
          logBody = true,
          logAction = Some(i => Sync[F].delay(println(s"Request: $i")))
        )(
          ResponseLogger[F](
            logHeaders = true,
            logBody = true,
            logAction = Some(i => Sync[F].delay(println(s"Response: $i")))
          )(client)
        ),
        process = process,
        apiKey = "<your-key-here>",
        endpoint = io.janstenpickle.trace4cats.newrelic.Endpoint.US
      )
    } yield EntryPoint[F](SpanSampler.always[F], completer)
  }

  def makeRoutes(client: Client[TracedEffect]): HttpRoutes[TracedEffect] = {
    object dsl extends Http4sDsl[TracedEffect]
    import dsl._

    HttpRoutes.of {
      case GET -> Root / "example" =>
        spannedRIOTrace.span("responding") {
          spannedRIOTrace.put("cal", 1) *>
            spannedRIOTrace.span("sleeping")(ZIO.sleep(1.second)) *>
            spannedRIOTrace.span("working")(
              ZIO.sleep(2.seconds) *>
                spannedRIOTrace.span("hardly") {
                  spannedRIOTrace.put("lolcats", 1) *> ZIO.unit
                }
            ) *>
            spannedRIOTrace.span("response")(spannedRIOTrace.traceId.flatMap(traceId => Ok(traceId.toString)))
        }

      case req @ GET -> Root / "forward" =>
        client.expect[String](req).flatMap(Ok(_))
    }
  }

  override def run(args: List[String]): URIO[ZEnv, ExitCode] = {
    implicit val spanProvide: Provide[Effect, TracedEffect, Span[Effect]] = zioProvideSome
    (for {
      ep <- entryPoint[Effect](TraceProcess("trace4catsHttp4s"))
      client <- BlazeClientBuilder[Effect].resource
      routes = makeRoutes(
        client.liftTrace[TracedEffect]()
      ) // use implicit syntax to lift http client to the trace context
      _ <-
        BlazeServerBuilder[Effect]
          .bindHttp(8080, "0.0.0.0")
          .withHttpApp(
            routes.inject(ep, requestFilter = Http4sRequestFilter.kubernetesPrometheus).orNotFound
          ) // use implicit syntax to inject an entry point to http routes
          .resource
    } yield ()).useForever.exitCode
  }
}
```

![image](https://user-images.githubusercontent.com/14280155/150199013-045dd1e1-e882-4931-a62c-39f0d8018177.png)

This also preserves the existing examples making use of the interop with no changes 😺

I would love to hear your feedback and I hope you would consider this change as it makes life so much easier thanks to the many integrations you have kindly provided. Please let me know if you want me to make any changes as I would love to work with you to get this merged 🙏🏽 

Thank you very much
Cal

P.S. the old implementation uses `Task` but I have widened this to `RIO[Clock & Blocking, *]` because the `zio.interop.catz.*` imports provide `Async` instances for this right out of the box. I noticed that interop with FS2 Kafka and HTTP4S usually end up using the same effect (RIO clock, blocking, etc.)  rather than Task which requires you to use ZIO.runtime[Clock & Blocking] to summon the necessary machinery via the ZIO runtime to summon typeclass instances for `Async[Task]`.  